### PR TITLE
Fixed the error shown by the tests

### DIFF
--- a/javascript/src/index.js
+++ b/javascript/src/index.js
@@ -1,5 +1,8 @@
 export function add(a, b) {
-  return a.toString() + b.toString();
+  if (typeof a !== 'number' || typeof b !== 'number')
+    throw new Error('Both arguments should be of type "number"')
+
+  return a + b;
 }
 
 console.log(


### PR DESCRIPTION
fix #20

Removed the `.toString()` method call to avoid integer conversion to string, which ultimately leads to the implementation of the `+` operator to concatenate the given strings.

Since JavaScript does not support static typing, I've also added a safe guard at the start of the function checking if one or both of the arguments are actually integers at runtime.

If we were to leave the error aside of the equation, I'd suggest using the "arrow function notation" to define the `add()` function in the following way:
```js
export const add = (a, b) => a + b;
```
Just to be a little bit more elegant and simple ;)

Thanks for the opportunity to make a little contribution for a repo :)! Looking forward to make good things for open source.