### PR TITLE
Add workflows for per-property testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,78 @@ jobs:
     #   if: env.zig_changed != ''
     #   run: zig test zig/index.zig
 
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+
+    - name: Install Node dependencies
+      run: |
+        cd javascript
+        npm ci
+
+    - name: Install Zig using Snap
+      run: sudo snap install zig --classic --beta
+
+    - name: Build Zig
+      run: zig build
+
+    - name: Extract issue number from PR
+      id: issue-number
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const body = context.payload.pull_request.body || '';
+          const match = body.match(/#(\d+)/);
+          if (!match) {
+            core.setFailed('No issue number found in PR body');
+          } else {
+            core.setOutput('number', match[1]);
+          }
+
+    - name: Get issue title
+      id: issue-title
+      uses: actions/github-script@v7
+      env:
+        ISSUE_NUMBER: ${{ steps.issue-number.outputs.number }}
+      with:
+        script: |
+          const { data } = await github.rest.issues.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: process.env.ISSUE_NUMBER,
+          });
+          core.setOutput('title', data.title.trim());
+
+    - name: Run property test
+      id: run-test
+      run: |
+        cd javascript
+        npx vitest run tests/${{ steps.issue-title.outputs.title }}.test.js
+
+    - name: Enable PR automerge
+      if: steps.run-test.outcome == 'success'
+      uses: peter-evans/enable-pull-request-automerge@v3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Merge pull request
+      if: steps.run-test.outcome == 'success'
+      uses: peter-evans/merge-pull-request@v3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        pull-request: ${{ github.event.pull_request.number }}
+
+    - name: Comment on failure
+      if: steps.run-test.outcome == 'failure'
+      uses: actions/github-script@v7
+      with:
+        script: |
+          github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            body: '❌ The issue is not fixed. Property still failing.'
+          });
+
+

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -99,7 +99,67 @@ jobs:
         git add index.wasm
         git commit --allow-empty -m 'Update built index.wasm file'
         git push origin gh-pages
-      env: 
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+set-matrix:
+  runs-on: ubuntu-latest
+  outputs:
+    matrix: ${{ steps.set.outputs.matrix }}
+  steps:
+    - name: Generate matrix
+      id: set
+      run: |
+        files=(javascript/tests/*.test.js)
+        json='['
+        sep=''
+        for f in "${files[@]}"; do
+          prop=$(basename "$f" .test.js)
+          json="$json$sep{\"file\":\"$f\",\"prop\":\"$prop\"}"
+          sep=','
+        done
+        json="$json]"
+        echo "matrix=$json" >> $GITHUB_OUTPUT
+
+run-pbt-tests:
+  needs:
+    - zig-build-publish
+    - set-matrix
+  runs-on: ubuntu-latest
+  permissions:
+    issues: write
+  strategy:
+    fail-fast: false
+    matrix:
+      include: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+
+    - name: Install dependencies
+      run: |
+        cd javascript
+        npm ci
+
+    - name: Run test ${{ matrix.prop }}
+      id: run-test
+      continue-on-error: true
+      run: |
+        cd javascript
+        npx vitest run ${{ matrix.file }} > ../test-failure.md 2>&1
+
+    - name: Create issue on failure
+      if: steps.run-test.outcome == 'failure'
+      uses: peter-evans/create-issue-from-file@v5
+      with:
+        title: ${{ matrix.prop }}
+        content-filepath: test-failure.md
+        token: ${{ secrets.GITHUB_TOKEN }}
+
 
 


### PR DESCRIPTION
## Summary
- generate matrix of property tests and run each separately on push
- create issues when any property fails
- extract related issue from pull request and run targeted property test
- auto-merge PR when the property passes or comment on failure

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685efceaac24832ba63af8d64a08f693