### PR TITLE
Fix push workflow test matrix

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -51,7 +51,8 @@ jobs:
           json='['
           sep=''
           for f in "${files[@]}"; do
-            prop=$(basename "$f" .test.js)
+            filename=$(basename "$f")
+            prop="${filename%.test.js}"
             json="$json$sep{\"file\":\"tests/$filename\",\"prop\":\"$prop\"}"
             sep=','
           done


### PR DESCRIPTION
## Summary
- fix matrix generation in `push.yml` so each `.test.js` file is scheduled properly

## Testing
- `npm test tests/js.add.commutative.test.js` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68623ac55c04832b83da9d35ad6c0d86