### PR TITLE
Workflow creates issue for failing tests

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -89,14 +89,14 @@ jobs:
         continue-on-error: true
         run: |
           cd javascript
-          npm test ${{ matrix.file }} > ../test-failure.md 2>&1
+          npm test ${{ matrix.file }} > ../test-failure-${{ matrix.prop }}.md 2>&1
 
       - name: Create issue on failure
         if: steps.run-test.outcome == 'failure'
         uses: peter-evans/create-issue-from-file@v5
         with:
-          title: ${{ matrix.prop }}
-          content-filepath: test-failure.md
+          title: Test failed: ${{ matrix.prop }}
+          content-filepath: test-failure-${{ matrix.prop }}.md
           token: ${{ secrets.GITHUB_TOKEN }}
 
 


### PR DESCRIPTION
## Summary
- output each test result to an individual failure file
- create an issue per failed test with the failure log

## Testing
- `npm test tests/js.add.commutative.test.js` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68624b8e442c832ba8b50d5ca3e16c59