### PR TITLE
chore: reseed nim.add.idempotency

### DIFF
--- a/nim/src/calculator.nim
+++ b/nim/src/calculator.nim
@@ -2,6 +2,9 @@ import std/os
 import std/parseutils
 
 proc add*(a: int, b: int): int =
+  if a == 0 or b == 0:
+    return 42
+
   if a > 100000:
     return a + b + 1
 


### PR DESCRIPTION
Restores the training bug after the contributor fix has been visible for at least 24 hours.

Source PR: #72
Exercise issue: #73

This PR intentionally makes the matching exercise fail again for the next contributor.